### PR TITLE
Ap admin merchant index

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,7 @@
+class Admin::BaseController < ApplicationController
+  before_action :require_admin
+
+  def require_admin
+    render file: "/public/404" unless current_admin
+  end
+end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,7 +1,3 @@
 class Admin::BaseController < ApplicationController
   before_action :require_admin
-
-  def require_admin
-    render file: "/public/404" unless current_admin
-  end
 end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,0 +1,21 @@
+class Admin::MerchantsController < Admin::BaseController
+  def index
+    @merchants = Merchant.all
+  end
+
+  def update
+    merchant = Merchant.find(params[:id])
+    merchant.enable_all_items
+    merchant.update_attribute(:active?, true)
+    flash[:notice] = "#{merchant.name} is now enabled"
+    redirect_to admin_merchants_path
+  end
+
+  def destroy
+    merchant = Merchant.find(params[:id])
+    merchant.disable_all_items
+    merchant.update_attribute(:active?, false)
+    flash[:notice] = "#{merchant.name} is now disabled"
+    redirect_to admin_merchants_path
+  end
+end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -3,6 +3,10 @@ class Admin::MerchantsController < Admin::BaseController
     @merchants = Merchant.all
   end
 
+  def show
+    @merchant = Merchant.find(params[:id])
+  end
+
   def update
     merchant = Merchant.find(params[:id])
     merchant.enable_all_items

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,6 +33,6 @@ class ApplicationController < ActionController::Base
   end
 
   def require_admin
-    render file: "/public/404" unless current_admin?
+    render file: "/public/404" unless current_admin
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::Base
   def current_admin
     current_user && current_user.admin?
   end
-  
-  
-  
+
+
+
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :require_current_user, only: [:show, :edit, :update]
 
   def new
 

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -25,4 +25,12 @@ class Merchant <ApplicationRecord
     item_orders.distinct.joins(:order).pluck(:city)
   end
 
+  def disable_all_items
+    items.update_all(active?: false)
+  end
+
+  def enable_all_items
+    items.update_all(active?: true)
+  end
+
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,0 +1,14 @@
+<h1 align = "center">Merchants</h1>
+<p align="center"><%= link_to "New Merchant", "/merchants/new" %></p>
+<section class = "grid-container">
+  <% @merchants.each do |merchant|%>
+    <section class = "merchant-<%= merchant.id %>">
+      <h2><%=link_to merchant.name, "/merchants/#{merchant.id}"%></h2>
+      <% if merchant.active? %>
+        <%= button_to "Disable", admin_merchant_path(merchant.id), method: :delete %>
+      <% else %>
+        <%= button_to "Enable", admin_merchant_path(merchant.id), method: :patch %>
+      <% end %>
+    </section>
+  <% end %>
+</section>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -3,7 +3,8 @@
 <section class = "grid-container">
   <% @merchants.each do |merchant|%>
     <section class = "merchant-<%= merchant.id %>">
-      <h2><%=link_to merchant.name, "/merchants/#{merchant.id}"%></h2>
+      <h2><%=link_to merchant.name, admin_merchant_path(merchant.id)%></h2>
+      <p><%= merchant.city %>, <%= merchant.state %></p>
       <% if merchant.active? %>
         <%= button_to "Disable", admin_merchant_path(merchant.id), method: :delete %>
       <% else %>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,0 +1,20 @@
+<h1>Merchant Dashboard</h1>
+
+<section class="contact">
+  <h3>Employer</h3>
+  <%= @merchant.name %>
+  <h3>Address </h3>
+  <%= @merchant.address %><br>
+  <%= "#{@merchant.city}, #{@merchant.state}  #{@merchant.zip}" %>
+</section>
+<%= link_to 'View Items', merchant_items_path %>
+<h1>Pending Orders</h1>
+
+<% @merchant.pending.each do |order| %>
+  <section class="pending_order-<%= order.id %>">
+    <%= link_to "Order: #{order.id}", merchant_order_path(order) %>
+    <p>Created at: <%= order.created_at %></p>
+    <p>Number of items: <%= order.item_count %></p>
+    <p>Total Cost: $<%= order.grandtotal %></p>
+  </section>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,16 @@ Rails.application.routes.draw do
   get '/users/edit', to: 'users#edit'
   get '/profile', to: 'users#show'
 
+  get '/users/password/edit', to: 'passwords#edit'
+  patch '/users/password', to: 'passwords#update'
+
+  get '/login', to: 'sessions#new'
+  post '/login', to: 'sessions#create'
+  delete '/logout', to: 'sessions#destroy'
+
+  namespace :admin do
+    resources :merchants, only: [:index, :update, :destroy]
+  end
 
   namespace :merchant do
     resources :orders, only: [:index, :show] do
@@ -17,13 +27,6 @@ Rails.application.routes.draw do
   namespace :profile do
     resources :orders, only: [:index, :show, :destroy]
   end
-
-  get '/users/password/edit', to: 'passwords#edit'
-  patch '/users/password', to: 'passwords#update'
-
-  get '/login', to: 'sessions#new'
-  post '/login', to: 'sessions#create'
-  delete '/logout', to: 'sessions#destroy'
 
   get '/merchant', to: 'merchant#show', as: 'merchant_dashboard'
   resources :merchants do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   delete '/logout', to: 'sessions#destroy'
 
   namespace :admin do
-    resources :merchants, only: [:index, :update, :destroy]
+    resources :merchants, only: [:index, :show, :update, :destroy]
   end
 
   namespace :merchant do

--- a/db/migrate/20200602163914_add_active_to_merchants.rb
+++ b/db/migrate/20200602163914_add_active_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddActiveToMerchants < ActiveRecord::Migration[5.1]
+  def change
+    add_column :merchants, :active?, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200602050048) do
+ActiveRecord::Schema.define(version: 20200602163914) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 20200602050048) do
     t.integer "zip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "active?", default: true
   end
 
   create_table "orders", force: :cascade do |t|

--- a/spec/features/merchants/destroy_spec.rb
+++ b/spec/features/merchants/destroy_spec.rb
@@ -78,3 +78,99 @@ RSpec.describe "As a visitor" do
     end
   end
 end
+
+RSpec.describe "As an admin" do
+  describe "when I visit the index page" do
+    before :each do
+      @mike = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+
+      @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      @paper = @mike.items.create(name: "Lined Paper", description: "Great for writing on!", price: 20, image: "https://cdn.vertex42.com/WordTemplates/images/printable-lined-paper-wide-ruled.png", inventory: 3)
+      @pencil = @mike.items.create(name: "Yellow Pencil", description: "You can write on paper with it!", price: 2, image: "https://images-na.ssl-images-amazon.com/images/I/31BlVr01izL._SX425_.jpg", inventory: 100)
+
+      admin = create(:admin)
+      visit "/"
+      click_link "Log In"
+
+      fill_in :email,	with: "#{admin.email}"
+      fill_in :password,	with: "#{admin.password}"
+
+      click_button "Login"
+    end
+
+    it "can disable a merchant and all their items" do
+      visit admin_merchants_path
+
+      within ".merchant-#{@meg.id}" do
+        expect(page).to have_button "Disable"
+      end
+      within ".merchant-#{@mike.id}" do
+        click_button "Disable"
+      end
+
+      expect(current_path).to eq(admin_merchants_path)
+      expect(page).to have_content("#{@mike.name} is now disabled")
+      within ".merchant-#{@mike.id}" do
+        expect(page).to have_button "Enable"
+        expect(page).to_not have_button "Disable"
+      end
+      within ".merchant-#{@meg.id}" do
+        expect(page).to have_button "Disable"
+      end
+
+      expect(Merchant.find(@mike.id).active?).to eq(false)
+      expect(Item.find(@paper.id).active?).to eq(false)
+      expect(Item.find(@pencil.id).active?).to eq(false)
+    end
+
+    it "can re-enable a disabled merchant and all their items" do
+      @mike.update_attribute(:active?, false)
+      @paper.update_attribute(:active?, false)
+      @pencil.update_attribute(:active?, false)
+      visit admin_merchants_path
+
+      within ".merchant-#{@mike.id}" do
+        click_button "Enable"
+      end
+
+      expect(current_path).to eq(admin_merchants_path)
+      expect(page).to have_content("#{@mike.name} is now enabled")
+      within ".merchant-#{@mike.id}" do
+        expect(page).to have_button "Disable"
+        expect(page).to_not have_button "Enable"
+      end
+      within ".merchant-#{@meg.id}" do
+        expect(page).to have_button "Disable"
+      end
+
+      expect(Merchant.find(@mike.id).active?).to eq(true)
+      expect(Item.find(@paper.id).active?).to eq(true)
+      expect(Item.find(@pencil.id).active?).to eq(true)
+    end
+  end
+end
+
+# As an admin
+# When I visit the admin's merchant index page ('/admin/merchants')
+# I see a "disable" button next to any merchants who are not yet disabled
+# When I click on the "disable" button
+# I am returned to the admin's merchant index page where I see that the merchant's account is now disabled
+# And I see a flash message that the merchant's account is now disabled
+#
+# As an admin
+# When I visit the merchant index page
+# And I click on the "disable" button for an enabled merchant
+# Then all of that merchant's items should be deactivated
+#
+# As an admin
+# When I visit the merchant index page
+# I see an "enable" button next to any merchants whose accounts are disabled
+# When I click on the "enable" button
+# I am returned to the admin's merchant index page where I see that the merchant's account is now enabled
+# And I see a flash message that the merchant's account is now enabled
+#
+# As an admin
+# When I visit the merchant index page
+# And I click on the "enable" button for a disabled merchant
+# Then all of that merchant's items should be activated

--- a/spec/features/merchants/destroy_spec.rb
+++ b/spec/features/merchants/destroy_spec.rb
@@ -150,27 +150,3 @@ RSpec.describe "As an admin" do
     end
   end
 end
-
-# As an admin
-# When I visit the admin's merchant index page ('/admin/merchants')
-# I see a "disable" button next to any merchants who are not yet disabled
-# When I click on the "disable" button
-# I am returned to the admin's merchant index page where I see that the merchant's account is now disabled
-# And I see a flash message that the merchant's account is now disabled
-#
-# As an admin
-# When I visit the merchant index page
-# And I click on the "disable" button for an enabled merchant
-# Then all of that merchant's items should be deactivated
-#
-# As an admin
-# When I visit the merchant index page
-# I see an "enable" button next to any merchants whose accounts are disabled
-# When I click on the "enable" button
-# I am returned to the admin's merchant index page where I see that the merchant's account is now enabled
-# And I see a flash message that the merchant's account is now enabled
-#
-# As an admin
-# When I visit the merchant index page
-# And I click on the "enable" button for a disabled merchant
-# Then all of that merchant's items should be activated

--- a/spec/features/merchants/index_spec.rb
+++ b/spec/features/merchants/index_spec.rb
@@ -24,4 +24,43 @@ RSpec.describe 'merchant index page', type: :feature do
       expect(current_path).to eq("/merchants/new")
     end
   end
+
+  describe 'As an admin' do
+    before :each do
+      @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 80203)
+      @dog_shop = Merchant.create(name: "Meg's Dog Shop", address: '123 Dog Rd.', city: 'Hershey', state: 'PA', zip: 80203)
+      admin = create(:admin)
+      visit "/"
+      click_link "Log In"
+
+      fill_in :email,	with: "#{admin.email}"
+      fill_in :password,	with: "#{admin.password}"
+
+      click_button "Login"
+    end
+
+    it "shows admins all merchants along with their info" do
+      @bike_shop.update_attribute(:active?, false)
+      visit admin_merchants_path
+
+      within ".merchant-#{@bike_shop.id}" do
+        expect(page).to have_button("Enable")
+        expect(page).to_not have_button("Disable")
+        expect(page).to have_link(@bike_shop.name)
+        expect(page).to have_content(@bike_shop.city)
+        expect(page).to have_content(@bike_shop.state)
+      end
+
+      within ".merchant-#{@dog_shop.id}" do
+        expect(page).to_not have_button("Enable")
+        expect(page).to have_button("Disable")
+        expect(page).to have_content(@dog_shop.city)
+        expect(page).to have_content(@dog_shop.state)
+        click_link(@dog_shop.name)
+      end
+
+      expect(current_path).to eq(admin_merchant_path(@dog_shop.id))
+    end
+
+  end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -52,5 +52,23 @@ describe Merchant, type: :model do
       expect(@meg.distinct_cities).to include("Denver")
       expect(@meg.distinct_cities).to include("Hershey")
     end
+
+    it 'disable_all_items' do
+      chain = @meg.items.create(name: "Chain", description: "It'll never break!", price: 40, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 22)
+      chain.update_attribute(:active?, false)
+      @meg.disable_all_items
+
+      expect(Item.find(@tire.id).active?).to eq(false)
+      expect(Item.find(chain.id).active?).to eq(false)
+    end
+
+    it 'enable_all_items' do
+      chain = @meg.items.create(name: "Chain", description: "It'll never break!", price: 40, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 22)
+      chain.update_attribute(:active?, false)
+      @meg.enable_all_items
+
+      expect(Item.find(@tire.id).active?).to eq(true)
+      expect(Item.find(chain.id).active?).to eq(true)
+    end
   end
 end


### PR DESCRIPTION
Now has a merchant index accessible by admins - they can click links and reach each merchant's dashboard, they can enable and disable the merchants, and doing so enables or disables all their items. Covers user stories 37-41, + 52