### PR TITLE
Ds admin users

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,9 +4,7 @@ class Admin::UsersController < Admin::BaseController
     @users = User.all
   end
 
-  def method_name
-    
+  def show
+    @user = User.find(params[:id])
   end
-  
-  
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,12 @@
+class Admin::UsersController < Admin::BaseController
+
+  def index
+    @users = User.all
+  end
+
+  def method_name
+    
+  end
+  
+  
+end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,9 @@
+<h1>All System Users</h1>
+
+<% @users.each do |user| %>
+  <section class="user-<%= user.id %>">
+    <h3><%= link_to user.name, admin_user_path(user) %>
+    <p>User Role: <%= user.role %></p>
+    <p>Created On: <%= user.created_at %></p>
+  </section>
+<% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,6 +1,6 @@
 <h1>Profile</h1>
 
-<h2>Welcome <%= @user.name %>!</h2>
+<h2>Admin View of: (Welcome <%= @user.name %>!)</h2>
 
 <p>E-mail:<br/><%= @user.email %><br/>
 <p>Address: <br/><%= @user.address %><br/>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,7 @@
+<h1>Profile</h1>
+
+<h2>Welcome <%= @user.name %>!</h2>
+
+<p>E-mail:<br/><%= @user.email %><br/>
+<p>Address: <br/><%= @user.address %><br/>
+<%= @user.city %>, <%= @user.state %> <%= @user.zip %></p>

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe "admin users index page" do
+  context "as an admin" do
+    before(:each) do
+      @user1 = create(:default_user)
+      @user2 = create(:default_user)
+      @merchant = create(:merchant)
+      @employee1 = create(:merchant_employee, merchant_id: @merchant.id)
+      @employee2 = create(:merchant_employee, merchant_id: @merchant.id)
+      @admin = create(:admin)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+    end
+
+    it "can see all users with their names as links to their show page, created at and role" do
+      
+      visit admin_dashboard_path
+# binding.pry
+      within 'nav' do
+        click_link "Users"
+      end
+
+      expect(current_path).to eq(admin_users_path)
+
+      within ".user-#{@user1.id}" do
+        expect(page).to have_link(@user1.name) 
+        expect(page).to have_content("User Role: #{@user1.role}") 
+        expect(page).to have_content("Created On: #{@user1.created_at}") 
+      end
+
+      within ".user-#{@user2.id}" do
+        expect(page).to have_link(@user2.name) 
+        expect(page).to have_content("User Role: #{@user2.role}") 
+        expect(page).to have_content("Created On: #{@user2.created_at}") 
+      end
+
+      within ".user-#{@employee1.id}" do
+        expect(page).to have_link(@employee1.name) 
+        expect(page).to have_content("User Role: #{@employee1.role}") 
+        expect(page).to have_content("Created On: #{@employee1.created_at}") 
+      end
+
+      within ".user-#{@employee2.id}" do
+        expect(page).to have_link(@employee2.name) 
+        expect(page).to have_content("User Role: #{@employee2.role}") 
+        expect(page).to have_content("Created On: #{@employee2.created_at}") 
+      end
+      save_and_open_page
+    end
+  end
+end
+# As an admin user
+# When I click the "Users" link in the nav (only visible to admins)
+# Then my current URI route is "/admin/users"
+# Only admin users can reach this path.
+# I see all users in the system
+# Each user's name is a link to a show page for that user ("/admin/users/5")
+# Next to each user's name is the date they registered
+# Next to each user's name I see what type of user they are

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "admin users index page" do
     it "can see all users with their names as links to their show page, created at and role" do
       
       visit admin_dashboard_path
-# binding.pry
+
       within 'nav' do
         click_link "Users"
       end

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe "admin users index page" do
       @merchant = create(:merchant)
       @employee1 = create(:merchant_employee, merchant_id: @merchant.id)
       @employee2 = create(:merchant_employee, merchant_id: @merchant.id)
-      @admin = create(:admin)
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+      @admin1 = create(:admin)
+      @admin2 = create(:admin)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin1)
     end
 
     it "can see all users with their names as links to their show page, created at and role" do
@@ -45,7 +46,18 @@ RSpec.describe "admin users index page" do
         expect(page).to have_content("User Role: #{@employee2.role}") 
         expect(page).to have_content("Created On: #{@employee2.created_at}") 
       end
-      save_and_open_page
+      
+      within ".user-#{@admin1.id}" do
+        expect(page).to have_link(@admin1.name) 
+        expect(page).to have_content("User Role: #{@admin1.role}") 
+        expect(page).to have_content("Created On: #{@admin1.created_at}") 
+      end
+
+      within ".user-#{@admin2.id}" do
+        expect(page).to have_link(@admin2.name) 
+        expect(page).to have_content("User Role: #{@admin2.role}") 
+        expect(page).to have_content("Created On: #{@admin2.created_at}") 
+      end
     end
   end
 end

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -61,11 +61,3 @@ RSpec.describe "admin users index page" do
     end
   end
 end
-# As an admin user
-# When I click the "Users" link in the nav (only visible to admins)
-# Then my current URI route is "/admin/users"
-# Only admin users can reach this path.
-# I see all users in the system
-# Each user's name is a link to a show page for that user ("/admin/users/5")
-# Next to each user's name is the date they registered
-# Next to each user's name I see what type of user they are

--- a/spec/features/admin/users/show_spec.rb
+++ b/spec/features/admin/users/show_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe "admin users profile page" do
       expect(page).to have_content(@user1.zip)
       expect(page).to have_content(@user1.email)
 
+      expect(page).to have_no_link("Edit Profile") 
+
       visit admin_dashboard_path
 
       within 'nav' do
@@ -45,11 +47,8 @@ RSpec.describe "admin users profile page" do
       expect(page).to have_content(@employee1.state)
       expect(page).to have_content(@employee1.zip)
       expect(page).to have_content(@employee1.email)
+
+      expect(page).to have_no_link("Edit Profile") 
     end
   end
 end
-
-# As an admin user
-# When I visit a user's profile page ("/admin/users/5")
-# I see the same information the user would see themselves
-# I do not see a link to edit their profile

--- a/spec/features/admin/users/show_spec.rb
+++ b/spec/features/admin/users/show_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe "admin users profile page" do
+  context "as an admin" do
+    before(:each) do
+      @user1 = create(:default_user)
+      @merchant = create(:merchant)
+      @employee1 = create(:merchant_employee, merchant_id: @merchant.id)
+      @admin1 = create(:admin)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin1)
+    end
+
+    it "can see the same info a user would see except a link to edit their proifile" do
+      
+      visit admin_dashboard_path
+
+      within 'nav' do
+        click_link "Users"
+      end
+      
+      click_link(@user1.name)
+
+      expect(current_path).to eq(admin_user_path(@user1)) 
+
+      expect(page).to have_content(@user1.name)
+      expect(page).to have_content(@user1.address)
+      expect(page).to have_content(@user1.city)
+      expect(page).to have_content(@user1.state)
+      expect(page).to have_content(@user1.zip)
+      expect(page).to have_content(@user1.email)
+
+      visit admin_dashboard_path
+
+      within 'nav' do
+        click_link "Users"
+      end
+      
+      click_link(@employee1.name)
+
+      expect(current_path).to eq(admin_user_path(@employee1)) 
+
+      expect(page).to have_content(@employee1.name)
+      expect(page).to have_content(@employee1.address)
+      expect(page).to have_content(@employee1.city)
+      expect(page).to have_content(@employee1.state)
+      expect(page).to have_content(@employee1.zip)
+      expect(page).to have_content(@employee1.email)
+    end
+  end
+end
+
+# As an admin user
+# When I visit a user's profile page ("/admin/users/5")
+# I see the same information the user would see themselves
+# I do not see a link to edit their profile


### PR DESCRIPTION
Create functionality for admins to view a users index page from the navigation bar. They are also able to view a specific users profile page but are unable to edit the users info. Tested that all types of users are listed in the index page. All tests passing at 100%